### PR TITLE
Update CI workflow and ruff to v0.14.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         exclude: .idea/.*
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.3
+    rev: v0.14.8
     hooks:
       - id: ruff
         args: [ --fix ]


### PR DESCRIPTION
## Summary
- Update CI workflow: remove Black/pre-commit jobs, add merge queue support
- Update ruff to v0.14.8 in pre-commit config
- Add `always()` pattern to release job to prevent skipped propagation

## Test plan
- [x] Ruff format check passes
- [x] Ruff lint check passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)